### PR TITLE
feat: add next-issue skill for automated issue workflow

### DIFF
--- a/.claude/skills/next-issue/SKILL.md
+++ b/.claude/skills/next-issue/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: next-issue
+description: Use when starting work on a GitHub issue - auto-selects lowest open issue without in-progress label, or accepts specific issue ID
+---
+
+# next-issue
+
+Pick and start work on a GitHub issue.
+
+## Usage
+
+- `/next-issue` - auto-select lowest available issue
+- `/next-issue 5` - work on issue #5
+
+## Workflow
+
+1. **Get issue** - if no ID provided, find lowest open issue without `in-progress` label
+2. **Add label** - mark issue as `in-progress`
+3. **Create branch** - `issue-{ID}` from `origin/main`
+4. **Show details** - display issue title and body
+5. **Start design** - invoke `superpowers:brainstorming`
+
+## Commands
+
+```bash
+# List available issues
+gh issue list --state open --json number,title,labels,body
+
+# Add label
+gh issue edit {ID} --add-label "in-progress"
+
+# Create branch from origin/main
+git fetch origin main
+git checkout -b issue-{ID} origin/main
+```
+
+## Error Cases
+
+- No open issues: inform user
+- Issue not found: inform user
+- Branch exists: ask user how to proceed
+- Not a git repo: inform user


### PR DESCRIPTION
## Summary
- Add `/next-issue` skill for automated GitHub issue workflow
- Auto-selects lowest open issue or accepts specific issue ID
- Creates branch, adds `in-progress` label, and starts brainstorming

## Test plan
- [x] Skill file created at `.claude/skills/next-issue/SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)