### PR TITLE
docs: add CI and license badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # agent-browser-go
 
+[![CI](https://github.com/fankaidev/agent-browser-go/actions/workflows/ci.yml/badge.svg)](https://github.com/fankaidev/agent-browser-go/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Node](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.5-blue)](https://www.typescriptlang.org/)
+
 Extended CLI wrapper for agent-browser.


### PR DESCRIPTION
## Summary
- Add CI status badge
- Add MIT license badge
- Add Node.js version badge
- Add TypeScript version badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)