### PR TITLE
feat: support three script types with different execution modes

### DIFF
--- a/sites/hn/top.js
+++ b/sites/hn/top.js
@@ -1,0 +1,4 @@
+/*
+type: api
+url: https://hacker-news.firebaseio.com/v0/topstories.json
+*/

--- a/sites/reddit/best.js
+++ b/sites/reddit/best.js
@@ -1,6 +1,5 @@
 /*
+type: fetch
+url: https://www.reddit.com/r/best.json?limit=50
 domain: reddit.com
 */
-fetch("https://www.reddit.com/best.json?limit=50")
-  .then((r) => r.json())
-  .then((d) => d.data);

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -82,4 +82,34 @@ type: invalid
 */`;
     expect(() => parseFrontmatter(content)).toThrow("Missing or invalid type");
   });
+
+  it("throws when api type missing url", () => {
+    const content = `/*
+type: api
+*/`;
+    expect(() => parseFrontmatter(content)).toThrow("api type requires url");
+  });
+
+  it("throws when fetch type missing url", () => {
+    const content = `/*
+type: fetch
+domain: example.com
+*/`;
+    expect(() => parseFrontmatter(content)).toThrow("fetch type requires url");
+  });
+
+  it("throws when fetch type missing domain", () => {
+    const content = `/*
+type: fetch
+url: https://example.com/api
+*/`;
+    expect(() => parseFrontmatter(content)).toThrow("fetch type requires domain");
+  });
+
+  it("throws when scrape type missing domain", () => {
+    const content = `/*
+type: scrape
+*/`;
+    expect(() => parseFrontmatter(content)).toThrow("scrape type requires domain");
+  });
 });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -20,28 +20,66 @@ describe("normalizeUrl", () => {
 });
 
 describe("parseFrontmatter", () => {
-  it("extracts domain from frontmatter", () => {
+  it("parses api type with url", () => {
     const content = `/*
-domain: reddit.com
-*/
-Array.from(document.querySelectorAll('h1'))`;
+type: api
+url: https://example.com/api
+*/`;
     const result = parseFrontmatter(content);
     expect(result).toEqual({
-      domain: "reddit.com",
-      body: "Array.from(document.querySelectorAll('h1'))",
+      type: "api",
+      url: "https://example.com/api",
+      domain: undefined,
+      body: "",
+    });
+  });
+
+  it("parses fetch type with url and domain", () => {
+    const content = `/*
+type: fetch
+url: https://example.com/api
+domain: example.com
+*/`;
+    const result = parseFrontmatter(content);
+    expect(result).toEqual({
+      type: "fetch",
+      url: "https://example.com/api",
+      domain: "example.com",
+      body: "",
+    });
+  });
+
+  it("parses scrape type with domain and body", () => {
+    const content = `/*
+type: scrape
+domain: example.com
+*/
+document.title`;
+    const result = parseFrontmatter(content);
+    expect(result).toEqual({
+      type: "scrape",
+      url: undefined,
+      domain: "example.com",
+      body: "document.title",
     });
   });
 
   it("throws on missing frontmatter", () => {
-    const content = `Array.from(document.querySelectorAll('h1'))`;
+    const content = `document.title`;
     expect(() => parseFrontmatter(content)).toThrow("Invalid frontmatter format");
   });
 
-  it("throws on missing domain", () => {
+  it("throws on missing type", () => {
     const content = `/*
-name: test
-*/
-body`;
-    expect(() => parseFrontmatter(content)).toThrow("Missing domain in frontmatter");
+url: https://example.com
+*/`;
+    expect(() => parseFrontmatter(content)).toThrow("Missing or invalid type");
+  });
+
+  it("throws on invalid type", () => {
+    const content = `/*
+type: invalid
+*/`;
+    expect(() => parseFrontmatter(content)).toThrow("Missing or invalid type");
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -123,6 +123,11 @@ function ab(subcommand: string): string {
   return exec(`agent-browser --session ${AB_SESSION} ${subcommand}`);
 }
 
+function runApi(url: string): void {
+  const result = execSync(`curl -s '${url}'`, { encoding: "utf-8" }).trim();
+  console.log(result);
+}
+
 function exec(command: string): string {
   if (debug) {
     console.error(`> ${command}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,17 @@ export function parseFrontmatter(content: string): ScriptConfig {
     throw new Error("Missing or invalid type in frontmatter");
   }
 
+  if (type === "api" && !urlMatch) {
+    throw new Error("api type requires url");
+  }
+  if (type === "fetch") {
+    if (!urlMatch) throw new Error("fetch type requires url");
+    if (!domainMatch) throw new Error("fetch type requires domain");
+  }
+  if (type === "scrape" && !domainMatch) {
+    throw new Error("scrape type requires domain");
+  }
+
   return {
     type,
     url: urlMatch?.[1]?.trim(),

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -128,6 +128,15 @@ function runApi(url: string): void {
   console.log(result);
 }
 
+function runFetch(domain: string, url: string): void {
+  const pageUrl = `https://${domain}`;
+  exec(`agent-browser open ${getOpenArgs()} '${pageUrl}'`);
+  exec("agent-browser wait --load networkidle");
+  const fetchCode = `fetch('${url}').then(r => r.json())`;
+  const result = exec(`agent-browser eval --json '${fetchCode}'`);
+  console.log(result);
+}
+
 function exec(command: string): string {
   if (debug) {
     console.error(`> ${command}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -96,24 +96,25 @@ function runScript(site: string, script: string): void {
   }
 
   const content = readFileSync(scriptPath, "utf-8");
-  let parsed: ScriptConfig;
+  let config: ScriptConfig;
   try {
-    parsed = parseFrontmatter(content);
-  } catch {
-    console.error(`Invalid script format in ${scriptPath}`);
+    config = parseFrontmatter(content);
+  } catch (e) {
+    console.error(`Invalid script format in ${scriptPath}: ${e instanceof Error ? e.message : e}`);
     process.exit(1);
   }
 
-  if (!parsed.domain) {
-    console.error(`Missing domain in ${scriptPath}`);
-    process.exit(1);
+  switch (config.type) {
+    case "api":
+      runApi(config.url!);
+      break;
+    case "fetch":
+      runFetch(config.domain!, config.url!);
+      break;
+    case "scrape":
+      runScrape(config.domain!, config.body);
+      break;
   }
-
-  const url = `https://${parsed.domain}`;
-  ab(`open ${getOpenArgs()} '${url}'`);
-  ab("wait --load networkidle");
-  const result = ab(`eval --json '${parsed.body.replace(/'/g, "'\\''")}'`);
-  console.log(result);
 }
 
 const WAIT_TIMEOUT = 60000;
@@ -130,18 +131,18 @@ function runApi(url: string): void {
 
 function runFetch(domain: string, url: string): void {
   const pageUrl = `https://${domain}`;
-  exec(`agent-browser open ${getOpenArgs()} '${pageUrl}'`);
-  exec("agent-browser wait --load networkidle");
+  ab(`open ${getOpenArgs()} '${pageUrl}'`);
+  ab("wait --load networkidle");
   const fetchCode = `fetch('${url}').then(r => r.json())`;
-  const result = exec(`agent-browser eval --json '${fetchCode}'`);
+  const result = ab(`eval --json '${fetchCode}'`);
   console.log(result);
 }
 
 function runScrape(domain: string, body: string): void {
   const url = `https://${domain}`;
-  exec(`agent-browser open ${getOpenArgs()} '${url}'`);
-  exec("agent-browser wait --load networkidle");
-  const result = exec(`agent-browser eval --json '${body.replace(/'/g, "'\\''")}'`);
+  ab(`open ${getOpenArgs()} '${url}'`);
+  ab("wait --load networkidle");
+  const result = ab(`eval --json '${body.replace(/'/g, "'\\''")}'`);
   console.log(result);
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -137,6 +137,14 @@ function runFetch(domain: string, url: string): void {
   console.log(result);
 }
 
+function runScrape(domain: string, body: string): void {
+  const url = `https://${domain}`;
+  exec(`agent-browser open ${getOpenArgs()} '${url}'`);
+  exec("agent-browser wait --load networkidle");
+  const result = exec(`agent-browser eval --json '${body.replace(/'/g, "'\\''")}'`);
+  console.log(result);
+}
+
 function exec(command: string): string {
   if (debug) {
     console.error(`> ${command}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,17 +9,35 @@ export function normalizeUrl(url: string): string {
   return url.startsWith("http://") || url.startsWith("https://") ? url : `https://${url}`;
 }
 
-export function parseFrontmatter(content: string): { domain: string; body: string } {
-  const match = content.match(/^\/\*\n([\s\S]*?)\n\*\/\n([\s\S]*)$/);
+export interface ScriptConfig {
+  type: "api" | "fetch" | "scrape";
+  url: string | undefined;
+  domain: string | undefined;
+  body: string;
+}
+
+export function parseFrontmatter(content: string): ScriptConfig {
+  const match = content.match(/^\/\*\n([\s\S]*?)\n\*\/\n?([\s\S]*)$/);
   if (!match) {
     throw new Error("Invalid frontmatter format");
   }
   const [, frontmatter, body] = match;
+
+  const typeMatch = frontmatter!.match(/^type:\s*(.+)$/m);
+  const urlMatch = frontmatter!.match(/^url:\s*(.+)$/m);
   const domainMatch = frontmatter!.match(/^domain:\s*(.+)$/m);
-  if (!domainMatch) {
-    throw new Error("Missing domain in frontmatter");
+
+  const type = typeMatch?.[1]?.trim() as ScriptConfig["type"] | undefined;
+  if (!type || !["api", "fetch", "scrape"].includes(type)) {
+    throw new Error("Missing or invalid type in frontmatter");
   }
-  return { domain: domainMatch[1]!.trim(), body: body!.trim() };
+
+  return {
+    type,
+    url: urlMatch?.[1]?.trim(),
+    domain: domainMatch?.[1]?.trim(),
+    body: body!.trim(),
+  };
 }
 
 let debug = false;
@@ -67,10 +85,15 @@ function runScript(site: string, script: string): void {
   }
 
   const content = readFileSync(scriptPath, "utf-8");
-  let parsed: { domain: string; body: string };
+  let parsed: ScriptConfig;
   try {
     parsed = parseFrontmatter(content);
   } catch {
+    console.error(`Invalid script format in ${scriptPath}`);
+    process.exit(1);
+  }
+
+  if (!parsed.domain) {
     console.error(`Missing domain in ${scriptPath}`);
     process.exit(1);
   }


### PR DESCRIPTION
## Summary

- Add three script execution modes based on frontmatter `type` field
- `api`: Direct HTTP request via curl (fastest, no browser)
- `fetch`: Browser session + fetch request (medium, uses cookies)
- `scrape`: Full browser automation (slowest, DOM parsing)

## Changes

- Extended `parseFrontmatter` to parse `type`, `url`, `domain` fields
- Added validation for required fields per type
- Added `runApi`, `runFetch`, `runScrape` execution functions
- Updated `runScript` dispatcher to route by type
- Added HN example (`sites/hn/top.js`) demonstrating api type
- Updated Reddit example to use fetch type

## Test plan

- [x] Unit tests for frontmatter parsing (14 tests pass)
- [x] Validation tests for required fields
- [x] Manual test: `pnpm dev hn top` returns JSON array
- [ ] Manual test: `pnpm dev reddit best` returns JSON (requires browser)

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)