### PR TITLE
feat(cli): require action argument and show error when missing

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,23 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normalizeUrl, parseFrontmatter } from "./cli.js";
-
-describe("normalizeUrl", () => {
-  it("adds https:// to bare domain", () => {
-    expect(normalizeUrl("example.com")).toBe("https://example.com");
-  });
-
-  it("keeps https:// url unchanged", () => {
-    expect(normalizeUrl("https://example.com")).toBe("https://example.com");
-  });
-
-  it("keeps http:// url unchanged", () => {
-    expect(normalizeUrl("http://example.com")).toBe("http://example.com");
-  });
-
-  it("handles domain with path", () => {
-    expect(normalizeUrl("example.com/path")).toBe("https://example.com/path");
-  });
-});
+import { parseFrontmatter, validateArgs } from "./cli.js";
 
 describe("parseFrontmatter", () => {
   it("extracts domain from frontmatter", () => {
@@ -43,5 +25,45 @@ name: test
 */
 body`;
     expect(() => parseFrontmatter(content)).toThrow("Missing domain in frontmatter");
+  });
+});
+
+describe("validateArgs", () => {
+  it("returns error when no arguments provided", () => {
+    const result = validateArgs([]);
+    expect(result).toEqual({
+      ok: false,
+      error: "Missing site argument",
+      usage: "Usage: abg <site> <action>",
+    });
+  });
+
+  it("returns error with available actions when action is missing", () => {
+    const result = validateArgs(["reddit"]);
+    expect(result).toEqual({
+      ok: false,
+      error: "Missing action argument",
+      usage: "Usage: abg <site> <action>",
+      actions: ["best"],
+    });
+  });
+
+  it("returns error with empty actions for unknown site", () => {
+    const result = validateArgs(["unknown"]);
+    expect(result).toEqual({
+      ok: false,
+      error: "Missing action argument",
+      usage: "Usage: abg <site> <action>",
+      actions: [],
+    });
+  });
+
+  it("returns success when site and action provided", () => {
+    const result = validateArgs(["reddit", "best"]);
+    expect(result).toEqual({
+      ok: true,
+      site: "reddit",
+      action: "best",
+    });
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,13 +1,9 @@
 #!/usr/bin/env node
 import { execSync } from "child_process";
-import { existsSync, readFileSync } from "fs";
+import { existsSync, readFileSync, readdirSync } from "fs";
 import { homedir } from "os";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
-
-export function normalizeUrl(url: string): string {
-  return url.startsWith("http://") || url.startsWith("https://") ? url : `https://${url}`;
-}
 
 export function parseFrontmatter(content: string): { domain: string; body: string } {
   const match = content.match(/^\/\*\n([\s\S]*?)\n\*\/\n([\s\S]*)$/);
@@ -22,12 +18,40 @@ export function parseFrontmatter(content: string): { domain: string; body: strin
   return { domain: domainMatch[1]!.trim(), body: body!.trim() };
 }
 
+export type ValidateResult =
+  | { ok: true; site: string; action: string }
+  | { ok: false; error: string; usage: string; actions?: string[] };
+
+export function getAvailableActions(sitesDir: string, site: string): string[] {
+  const siteDir = join(sitesDir, site);
+  if (!existsSync(siteDir)) {
+    return [];
+  }
+  const files = readdirSync(siteDir);
+  return files.filter((f) => f.endsWith(".js")).map((f) => f.replace(/\.js$/, ""));
+}
+
+export function validateArgs(args: string[], sitesDir?: string): ValidateResult {
+  const usage = "Usage: abg <site> <action>";
+
+  if (args.length === 0) {
+    return { ok: false, error: "Missing site argument", usage };
+  }
+
+  if (args.length === 1) {
+    const site = args[0]!;
+    const dir = sitesDir ?? getSitesDir();
+    const actions = getAvailableActions(dir, site);
+    return { ok: false, error: "Missing action argument", usage, actions };
+  }
+
+  return { ok: true, site: args[0]!, action: args[1]! };
+}
+
 let debug = false;
 
 function printUsage() {
-  console.log("Usage:");
-  console.log("  abg [--debug] <url>              Opens URL and prints page title");
-  console.log("  abg [--debug] <site> <script>    Runs sites/<site>/<script>.js");
+  console.log("Usage: abg [--debug] <site> <action>");
   console.log("");
   console.log("Options:");
   console.log("  --debug    Print agent-browser commands before executing");
@@ -107,24 +131,26 @@ function main() {
     args = args.slice(1);
   }
 
-  if (args.length === 0 || args[0] === "--help" || args[0] === "-h") {
+  if (args[0] === "--help" || args[0] === "-h") {
     printUsage();
-    process.exit(args.length === 0 ? 1 : 0);
+    process.exit(0);
   }
 
-  if (args.length === 2) {
-    runScript(args[0]!, args[1]!);
-    return;
+  const validation = validateArgs(args);
+  if (!validation.ok) {
+    console.error(`Error: ${validation.error}`);
+    console.error(validation.usage);
+    if (validation.actions && validation.actions.length > 0) {
+      console.error("");
+      console.error(`Available actions for ${args[0]}:`);
+      for (const action of validation.actions) {
+        console.error(`  ${action}`);
+      }
+    }
+    process.exit(1);
   }
 
-  const url = args[0]!;
-  const fullUrl = normalizeUrl(url);
-
-  ab(`open ${getOpenArgs()} '${fullUrl}'`);
-  ab("wait --load networkidle");
-  const title = ab("eval 'document.title'");
-
-  console.log(JSON.stringify({ title }));
+  runScript(validation.site, validation.action);
 }
 
 // Only run main when executed directly


### PR DESCRIPTION
## Summary
- Remove URL-only mode (`abg <url>`) — CLI now requires both `<site>` and `<action>`
- Show clear error message when site argument is missing
- Show available actions when action argument is missing

Closes #9

## Test plan
- [x] `pnpm dev` shows "Missing site argument" error
- [x] `pnpm dev reddit` shows "Missing action argument" with available actions
- [x] `pnpm dev reddit best` works as expected
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)